### PR TITLE
Better bash script

### DIFF
--- a/bin/.merge
+++ b/bin/.merge
@@ -3,7 +3,9 @@
 ARGUMENT="$1"
 #determine aux name by stripping .tex suffix and adding .aux
 AUXNAME="${ARGUMENT%.tex}.aux"
-pdflatex -shell-escape -interaction=nonstopmode -file-line-error "$ARGUMENT" | grep ".*:[0-9]*:.*"
-bibtex -terse "$AUXNAME"
-pdflatex -shell-escape -interaction=nonstopmode -file-line-error "$ARGUMENT" | grep ".*:[0-9]*:.*"
-pdflatex -shell-escape -interaction=nonstopmode -file-line-error "$ARGUMENT" | grep ".*:[0-9]*:.*"
+
+pdflatex='pdflatex -shell-escape -interaction=nonstopmode -file-line-error '$ARGUMENT
+bibtex='bibtex -terse '$AUXNAME
+($pdflatex && $bibtex && $pdflatex && $pdflatex) | grep ".*:[0-9]*:.*"
+
+exit ${PIPESTATUS[0]}

--- a/bin/watchdog_latex
+++ b/bin/watchdog_latex
@@ -1,6 +1,8 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+
 # The original file by http://dev.im-bot.com/2014/07/20/watchdog/
-# /usr/bin/env python
+# usr/bin/python3
+
 import os
 import sys
 import time


### PR DESCRIPTION
@mildronize I try to make this better but I didn't do fully test. Could you check this ?
# bin/watchdog_latex

It should use #!/usr/bin/env python3 instead of #!/usr/bin/python3 which more portable that some machine may not install python in /usr/bin.

References: http://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my#answer-29611
# bin/.merge

The old way will compile 3 times even some was failed that should stop and exit, not do any command any more. 

The new way use && operator to execute each command only if the previous one succeeded and return correct the exit code that should be compile command not exit code of grep command. You can look exited which `$ echo $?` when command done that 0 for success, 1 for failed/error.

Ref:
http://stackoverflow.com/questions/13077241/execute-combine-multiple-linux-commands-in-one-line
http://stackoverflow.com/questions/90418/exit-shell-script-based-on-process-exit-code/493676#493676
